### PR TITLE
Fix TechRadar link for tech/README.md

### DIFF
--- a/tech/README.md
+++ b/tech/README.md
@@ -19,7 +19,7 @@
 <img src="https://cdn.svgporn.com/logos/terraform-icon.svg" alt="terraform" width="25" height="25" />
 </p>
 
-С полным стеком наших технологий можно познакомиться в [технологическом радаре](https://radar.thoughtworks.com/?sheetId=https://raw.githubusercontent.com/magnit-tech/tech-radar/master/%D0%A2%D0%B5%D1%85%D0%BD%D0%BE%D0%BB%D0%BE%D0%B3%D0%B8%D1%87%D0%B5%D1%81%D0%BA%D0%B8%D0%B9%20%D1%80%D0%B0%D0%B4%D0%B0%D1%80%20%D0%BE%D1%82%D0%B4%D0%B5%D0%BB%D0%B0%20%D0%BE%D0%BD%D0%BB%D0%B0%D0%B9%D0%BD%20%D1%80%D0%B0%D0%B7%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D0%BA%D0%B8.csv).
+С полным стеком наших технологий можно познакомиться в [технологическом радаре](https://magnit-tech.github.io/magnit-online/tech/radar/index.html).
 
 ## Общий стек
 


### PR DESCRIPTION
Currently, [tech/README.md](https://github.com/magnit-tech/magnit-online/blob/master/tech/README.md) uses a link to https://radar.thoughtworks.com/ with an incorrectly formatted `sheetId`. In [magnit-tech/tech-radar/Технологический радар отдела онлайн разработки.csv](https://github.com/magnit-tech/tech-radar/blob/master/%D0%A2%D0%B5%D1%85%D0%BD%D0%BE%D0%BB%D0%BE%D0%B3%D0%B8%D1%87%D0%B5%D1%81%D0%BA%D0%B8%D0%B9%20%D1%80%D0%B0%D0%B4%D0%B0%D1%80%20%D0%BE%D1%82%D0%B4%D0%B5%D0%BB%D0%B0%20%D0%BE%D0%BD%D0%BB%D0%B0%D0%B9%D0%BD%20%D1%80%D0%B0%D0%B7%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D0%BA%D0%B8.csv), the quadrant names (`languages, data management, frameworks & libraries`) are invalid and not natively supported by [thoughtworks/build-your-own-radar](https://github.com/thoughtworks/build-your-own-radar?tab=readme-ov-file#setting-up-your-data) (which expects `tools, techniques, platforms, languages & frameworks`).

This PR replaces the link with https://magnit-tech.github.io/magnit-online/tech/radar/index.html, following the same pattern as the links in [README.md](https://github.com/magnit-tech/magnit-online/blob/master/README.md#%D0%BF%D0%BE%D0%BB%D0%B5%D0%B7%D0%BD%D1%8B%D0%B5-%D1%81%D1%81%D1%8B%D0%BB%D0%BA%D0%B8), [tech/devops.md](https://github.com/magnit-tech/magnit-online/blob/master/tech/devops.md), [tech/golang.md](https://github.com/magnit-tech/magnit-online/blob/master/tech/golang.md)...

---

Alternative Solution:
An alternative fix would be updating the quadrant names in [magnit-tech/tech-radar](https://github.com/magnit-tech/tech-radar) to match the expected format in [thoughtworks/build-your-own-radar](https://github.com/thoughtworks/build-your-own-radar?tab=readme-ov-file#setting-up-your-data). However, based on commit dates, the TechRadar files in [magnit-tech/tech-radar](https://github.com/magnit-tech/tech-radar) appear less up-to-date than those in [magnit-tech/magnit-online/tech/radar](https://github.com/magnit-tech/magnit-online/tree/master/tech/radar).

---

<details>

<summary>If you follow the current link from the tech/README.md, you will see an empty tech radar 🏞️</summary>

<img width="1112" alt="Снимок экрана 2025-04-16 в 19 18 22" src="https://github.com/user-attachments/assets/b7ce2b49-9d76-415b-b492-dc8e7d481f9d" />

</details>
